### PR TITLE
Update: Added an optional endpoint to GCS filesystem schema

### DIFF
--- a/filesystem.go
+++ b/filesystem.go
@@ -119,6 +119,7 @@ type BaseGCSFsConfig struct {
 	CredentialFile string `json:"-"`
 	// 0 explicit, 1 automatic
 	AutomaticCredentials int    `json:"automatic_credentials,omitempty"`
+	Endpoint             string `json:"endpoint,omitempty"`
 	StorageClass         string `json:"storage_class,omitempty"`
 	// The ACL to apply to uploaded objects. Leave empty to use the default ACL.
 	// For more information and available ACLs, refer to the JSON API here:


### PR DESCRIPTION
The goal is to let a user to specify their custom GCS endpoint like it's done in AWS and Azure environment.

# Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://sftpgo.com/cla.html)?

---
